### PR TITLE
Add simple daily reminder program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# estudo
+# Estudo - Lembrete de Atividades Diárias
+
+Este repositório contém um pequeno programa em Python que exibe lembretes de atividades diárias com base em um arquivo `atividades.json`.
+
+## Como usar
+
+1. Instale as dependências necessárias:
+
+```bash
+pip install schedule
+```
+
+2. Edite o arquivo `atividades.json` para incluir suas atividades e horários no formato `HH:MM`.
+
+3. Execute o programa:
+
+```bash
+python remind.py
+```
+
+O script permanecerá em execução e exibirá mensagens no terminal nos horários configurados.
+
+## Exemplo de `atividades.json`
+
+```json
+[
+    {"hora": "09:00", "atividade": "Tomar café da manhã"},
+    {"hora": "12:00", "atividade": "Almoçar"},
+    {"hora": "18:00", "atividade": "Jantar"}
+]
+```
+

--- a/atividades.json
+++ b/atividades.json
@@ -1,0 +1,5 @@
+[
+    {"hora": "09:00", "atividade": "Tomar café da manhã"},
+    {"hora": "12:00", "atividade": "Almoçar"},
+    {"hora": "18:00", "atividade": "Jantar"}
+]

--- a/remind.py
+++ b/remind.py
@@ -1,0 +1,41 @@
+import json
+import schedule
+import time
+from datetime import datetime
+
+
+def carregar_atividades(caminho='atividades.json'):
+    try:
+        with open(caminho, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return []
+
+
+def lembrar(atividade):
+    horario = datetime.now().strftime('%H:%M')
+    print(f"[{horario}] Lembrete: {atividade}")
+
+
+def agendar_atividades(atividades):
+    for item in atividades:
+        hora = item.get('hora')
+        nome = item.get('atividade')
+        if hora and nome:
+            schedule.every().day.at(hora).do(lembrar, nome)
+
+
+def main():
+    atividades = carregar_atividades()
+    if not atividades:
+        print('Nenhuma atividade encontrada em atividades.json.')
+        return
+    agendar_atividades(atividades)
+    print('Iniciando lembretes de atividades... (Ctrl+C para sair)')
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `remind.py` to schedule daily reminders
- add example data file `atividades.json`
- document usage of the reminder script in `README.md`

## Testing
- `python -m py_compile remind.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f101b970832a8d3cb3f78fe992ff